### PR TITLE
Fixes for missing stop codon in translation and FTP issue for importGenome

### DIFF
--- a/pyGeno/Protein.py
+++ b/pyGeno/Protein.py
@@ -55,7 +55,7 @@ class Protein(pyGenoRabaObjectWrapper) :
 		return pyGenoRabaObjectWrapper._makeLoadQuery(self, objectType, *args, **coolArgs)
 	
 	def _load_sequences(self) :
-		self.sequence = uf.translateDNA(self.transcript.cDNA[:-3])
+		self.sequence = uf.translateDNA(self.transcript.cDNA).rstrip('*')
 	
 	def getSequence(self):
 		return self.sequence

--- a/pyGeno/importation/Genomes.py
+++ b/pyGeno/importation/Genomes.py
@@ -1,4 +1,4 @@
-import os, glob, gzip, tarfile, shutil, time, sys, gc, cPickle, tempfile, urllib
+import os, glob, gzip, tarfile, shutil, time, sys, gc, cPickle, tempfile, urllib2, contextlib
 from ConfigParser import SafeConfigParser
 
 from pyGeno.tools.ProgressBar import ProgressBar
@@ -43,7 +43,11 @@ def _getFile(fil, directory) :
 	if fil.find("http://") == 0 or fil.find("ftp://") == 0 :
 		printf("Downloading file: %s..." % fil)
 		finalFile = os.path.normpath('%s/%s' %(directory, fil.split('/')[-1]))
-		urllib.urlretrieve (fil, finalFile)
+		#urllib.urlretrieve (fil, finalFile)
+		with closing(urllib2.urlopen(fil)) as r:
+                    with open(finalFile, 'wb') as f:
+                        shutil.copyfileobj(r, f)
+		
 		printf('done.')
 	else :
 		finalFile = os.path.normpath('%s/%s' %(directory, fil))

--- a/pyGeno/importation/Genomes.py
+++ b/pyGeno/importation/Genomes.py
@@ -1,4 +1,5 @@
-import os, glob, gzip, tarfile, shutil, time, sys, gc, cPickle, tempfile, urllib2, contextlib
+import os, glob, gzip, tarfile, shutil, time, sys, gc, cPickle, tempfile, urllib2
+from contextlib import closing
 from ConfigParser import SafeConfigParser
 
 from pyGeno.tools.ProgressBar import ProgressBar

--- a/pyGeno/tools/ProgressBar.py
+++ b/pyGeno/tools/ProgressBar.py
@@ -93,7 +93,7 @@ class ProgressBar :
 				if snakeLen + voidLen < self.width :
 					snakeLen = self.width - voidLen
 				
-				self.bar = "%s %s[%s:>%s] %.2f%% (%d/%d) runtime: %s, remaing: %s, avg: %s" %(wheelState, slabel, "~-" * snakeLen, "  " * voidLen, ratio*100, self.currEpoch, self.nbEpochs, self.runtime_hr, self.remtime_hr, self.formatTime(self.avg))
+				self.bar = "%s %s[%s:>%s] %.2f%% (%d/%d) runtime: %s, remaining: %s, avg: %s" %(wheelState, slabel, "~-" * snakeLen, "  " * voidLen, ratio*100, self.currEpoch, self.nbEpochs, self.runtime_hr, self.remtime_hr, self.formatTime(self.avg))
 				if self.currEpoch == self.nbEpochs :
 					self.close()
 				


### PR DESCRIPTION
Fixes the following issue that occurs on some host for importing Genome

import pyGeno.bootstrap as B
B.printDatawraps()
B.importGenome('Mouse.GRCm38.78.tar.gz')

Importing genome package: /usr/src/app/pyGeno/bootstrap_data/genomes/Mouse.GRCm38.78.tar.gz... (This may take a while)
Downloading file: ftp://ftp.ensembl.org/pub/release-78/gtf/mus_musculus/Mus_musculus.GRCm38.78.gtf.gz...
done.
Downloading file: ftp://ftp.ensembl.org/pub/release-78/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.chromosome.10.fa.gz...
done.
Downloading file: ftp://ftp.ensembl.org/pub/release-78/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.chromosome.11.fa.gz...
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/usr/src/app/pyGeno/bootstrap.py", line 105, in importGenome
PG.importGenome(path, batchSize)
File "/usr/src/app/pyGeno/importation/Genomes.py", line 159, in importGenome
chromosomesFiles[key] = _getFile(fil, packageDir)
File "/usr/src/app/pyGeno/importation/Genomes.py", line 46, in _getFile
urllib.urlretrieve (fil, finalFile)
File "/usr/local/lib/python2.7/urllib.py", line 98, in urlretrieve
return opener.retrieve(url, filename, reporthook, data)
File "/usr/local/lib/python2.7/urllib.py", line 245, in retrieve
fp = self.open(url, data)
File "/usr/local/lib/python2.7/urllib.py", line 213, in open
return getattr(self, name)(url)
File "/usr/local/lib/python2.7/urllib.py", line 558, in open_ftp
(fp, retrlen) = self.ftpcache[key].retrfile(file, type)
File "/usr/local/lib/python2.7/urllib.py", line 906, in retrfile
conn, retrlen = self.ftp.ntransfercmd(cmd)
File "/usr/local/lib/python2.7/ftplib.py", line 334, in ntransfercmd
host, port = self.makepasv()
File "/usr/local/lib/python2.7/ftplib.py", line 312, in makepasv
host, port = parse227(self.sendcmd('PASV'))
File "/usr/local/lib/python2.7/ftplib.py", line 830, in parse227
raise error_reply, resp
IOError: [Errno ftp error] 200 Type set to I
