### PR TITLE
Fixes CDS frame

### DIFF
--- a/pyGeno/Transcript.py
+++ b/pyGeno/Transcript.py
@@ -104,7 +104,8 @@ class Transcript(pyGenoRabaObjectWrapper) :
 				if len(cDNA) == 0 and e.frame != 0 :
 					e.CDS = e.CDS[e.frame:]
 				
-				cDNA.append(''.join(e.CDS))
+				if len(e.CDS):
+					cDNA.append(''.join(e.CDS))
 				UTR3.append(''.join(e.UTR3))
 				prime5 = False
 			else :


### PR DESCRIPTION
In ENSMUST00000163141, the first exon gets empty after fixing the reading frame.  In that case, we need to fix the second exon reading frame and do not add the first empty exon to the cDNA. A single occurrence of this issue was found in GRCm38.87.