### PR TITLE
Reduces memory usage and improves speed

### DIFF
--- a/pyGeno/Chromosome.py
+++ b/pyGeno/Chromosome.py
@@ -86,7 +86,7 @@ class ChrosomeSequence(object) :
 		return data
 	
 	def _getSequence(self, slic) :
-		return ''.join(self.getSequenceData(slice(0, None, 1)))[slic]
+		return ''.join(self.getSequenceData(slic))
 
 	def __getitem__(self, i) :
 		return self._getSequence(i)


### PR DESCRIPTION
Current slicing/join was concatenating the whole chromosome sequence when only a slice was required. That required 2-3 GB of memory in some case and it was slow in my use case:

Before
![plot_old](https://user-images.githubusercontent.com/1862936/40672307-6ca72c72-633c-11e8-865b-a3a0b3d59f10.png)

I suggest reverting back to original pyGeno code that was changed by @ericloud .

After

![plot_new](https://user-images.githubusercontent.com/1862936/40672318-758f7506-633c-11e8-8fa2-24ea941ad613.png)

@ericloud 
Is this a problem with your bug reported here:
https://github.com/tariqdaouda/pyGeno/commit/2fd3fbe93916c837aeeb59564e171bc047902736#diff-9a0352f44c9b0e9b00e4e2df44eae54b