### PR TITLE
Fixed bug in python version check

### DIFF
--- a/pyGeno/configuration.py
+++ b/pyGeno/configuration.py
@@ -36,7 +36,7 @@ def prettyVersion() :
 def checkPythonVersion() :
 	"""pyGeno needs python 3.5+"""
 	
-	if sys.version_info[0] < 3 or (sys.version_info[0] > 3  and sys.version_info[1] < 5) :
+	if sys.version_info[0] < 3 or (sys.version_info[0] == 3  and sys.version_info[1] < 5) :
 		return False
 	return True
 


### PR DESCRIPTION
Same bug present in Issue #51 - does not accurately check for 3.5+.

```
if sys.version_info[0] < 3 or (sys.version_info[0] > 3  and sys.version_info[1] < 5) :
		return False
return True
```

Returns True for all versions of Python 3 and (would return) False for versions 4.0-4.4.