### PR TITLE
fix: convert Python 2 print/input syntax to Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+CODE FREEZE:
+============
+
+We are working on a major port of pyGeno the open-source multi-modal database ArangoDB. PyGeno's code on both branches master and bloody is frozen until we are finished. No pull request will be merged until then, and we won't implement any new features.
+
 pyGeno: A Python package for precision medicine and proteogenomics
 ==================================================================
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 CODE FREEZE:
 ============
 
-PyGeno has long been limited due to it's SQLite backend. We are now ready to take it to the next level.
+PyGeno has long been limited due to it's backend. We are now ready to take it to the next level.
 
 We are working on a major port of pyGeno to the open-source multi-modal database ArangoDB. PyGeno's code on both branches master and bloody is frozen until we are finished. No pull request will be merged until then, and we won't implement any new features.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,9 @@
 CODE FREEZE:
 ============
 
-We are working on a major port of pyGeno the open-source multi-modal database ArangoDB. PyGeno's code on both branches master and bloody is frozen until we are finished. No pull request will be merged until then, and we won't implement any new features.
+PyGeno as long been limited due to it's SQLite backend. We are now ready to take it to the next level.
+
+We are working on a major port of pyGeno to the open-source multi-modal database ArangoDB. PyGeno's code on both branches master and bloody is frozen until we are finished. No pull request will be merged until then, and we won't implement any new features.
 
 pyGeno: A Python package for precision medicine and proteogenomics
 ==================================================================

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 CODE FREEZE:
 ============
 
-PyGeno as long been limited due to it's SQLite backend. We are now ready to take it to the next level.
+PyGeno has long been limited due to it's SQLite backend. We are now ready to take it to the next level.
 
 We are working on a major port of pyGeno to the open-source multi-modal database ArangoDB. PyGeno's code on both branches master and bloody is frozen until we are finished. No pull request will be merged until then, and we won't implement any new features.
 

--- a/pyGeno/tools/io.py
+++ b/pyGeno/tools/io.py
@@ -3,21 +3,21 @@ import sys
 def printf(*s) :
 	'print + sys.stdout.flush()'
 	for e in s[:-1] :
-		print e,
-	print s[-1]
+		print(e, end=' ')
+	print(s[-1])
 
 	sys.stdout.flush()
 
 def enterConfirm_prompt(enterMsg) :
 	stopi = False
 	while not stopi :
-		print "====\n At any time you can quit by entering 'quit'\n===="
-		vali = raw_input(enterMsg)
+		print("====\n At any time you can quit by entering 'quit'\n====")
+		vali = input(enterMsg)
 		if vali.lower() == 'quit' :
 			vali = None
 			stopi = True
 		else :
-			print "You've entered:\n\t%s" % vali
+			print("You've entered:\n\t%s" % vali)
 			valj = confirm_prompt("")
 			if valj == 'yes' :
 				stopi = True
@@ -29,7 +29,7 @@ def enterConfirm_prompt(enterMsg) :
 
 def confirm_prompt(preMsg) :
 	while True :
-		val = raw_input('%splease confirm ("yes", "no", "quit"): ' % preMsg)
+		val = input('%splease confirm ("yes", "no", "quit"): ' % preMsg)
 		if val.lower() == 'yes' or val.lower() == 'no' or val.lower() == 'quit':
 			return val.lower()
 		


### PR DESCRIPTION
Fixed Python 2 syntax issues in pyGeno/tools/io.py:

**Before:**
```python
print e,              # Python 2 print statement
raw_input(enterMsg)   # Python 2 raw_input
```

**After:**
```python
print(e, end=" ")     # Python 3 print function
input(enterMsg)       # Python 3 input (= Python 2 raw_input)
```

This fixes syntax errors on Python 3 interpreters. — Sent via @AmSach bot